### PR TITLE
Allowing lambda.discard with user specified values

### DIFF
--- a/R/hrq_glasso.R
+++ b/R/hrq_glasso.R
@@ -137,7 +137,7 @@ hrq_glasso<- function(x, y, group.index, tau=0.5, lambda=NULL, weights=NULL, w.l
     lambda<- exp(seq(log(lambda.max), log(lambda.min), length.out = 101))
   }else{
     # user supplied lambda
-    lambda.discard<- FALSE
+    #lambda.discard<- FALSE
     if(lambda.max> max(lambda)){
       lambda<- exp(c(log(lambda.max), log(sort(lambda, decreasing = TRUE))))
     }else{

--- a/ignore/test.R
+++ b/ignore/test.R
@@ -4,7 +4,7 @@ devtools::unload("rqPen")
 devtools::unload("hrqglas")
 install_github("shaobo-li/hrqglas")
 3
-install_github("bssherwood/rqpen")
+install_github("bssherwood/hrqglas")
 3
 library(rqPen)
 library(hrqglas)
@@ -18,13 +18,13 @@ groups <- c(rep(1,4),rep(2,3),rep(3,3),rep(4,3))
 
 #r1 <- rq.pen(x,y)
 lamMax <- rqPen:::getLamMaxGroup(x, y, groups, .5, rep(1,4), 
-                         penalty = "gLASSO", scalex=TRUE)
+                         penalty = "gLASSO", scalex=TRUE,tau.penalty.factor=1)
 eps <- ifelse(nrow(x) < ncol(x), 0.01, 1e-04)
 nlambda <- 100
 lambda <- exp(seq(log(lamMax), log(eps * lamMax), length.out = nlambda))
 
-h0 <- hrq_glasso(x,y,groups,tau=.5)
-h1 <- hrq_glasso(x,y,groups,tau=.5,lambda=lambda)
+h0 <- hrq_glasso(x,y,groups,tau=.5, w.lambda=rep(1,4))#weird cutting off first lambda and also doesn't quite match with these next two
+h1 <- hrq_glasso(x,y,groups,tau=.5,lambda=lambda, w.lambda=rep(1,4))
 r1 <- rq.group.pen(x,y,groups=groups)
 
 
@@ -54,6 +54,8 @@ gamma.max <- 4
 gamma0 <- .2
 weights <- rep(1,n)
 group.index <- groups
+w.lambda <- rep(1,4)
+x <- scale(x)
 
 b.int<- quantile(y, probs = tau)
 r<- y-b.int
@@ -62,8 +64,8 @@ gamma<- min(gamma.max, max(gamma0, quantile(abs(r), probs = 0.1)))
 
 r0 <- r
 apprx <- "huber"
-grad_k<- -hrqglas:::neg.gradient(r0, weights, tau, gamma=gamma, x, n, apprx)
-grad_k.norm<- tapply(grad_k, group.index, hrqglas:::l2norm)
+grad_k2 <- -hrqglas:::neg.gradient(r0, weights, tau, gamma=gamma, x, n, apprx)
+grad_k.norm<- tapply(grad_k2, group.index, hrqglas:::l2norm)
 
 lambda.max<- max(grad_k.norm/w.lambda)
 

--- a/ignore/test.R
+++ b/ignore/test.R
@@ -4,7 +4,8 @@ devtools::unload("rqPen")
 devtools::unload("hrqglas")
 install_github("bssherwood/hrqglas")
 3
-install_github("bssherwood/rqPen")
+install_github("shaobo-li/rqPen")
+#install_github("bssherwood/rqPen")
 3
 library(rqPen)
 library(hrqglas)

--- a/ignore/test.R
+++ b/ignore/test.R
@@ -1,3 +1,9 @@
+rm(list=ls(all=TRUE))
+library(devtools)
+devtools::unload("rqPen")
+devtools::unload("hrqglas")
+install_github("shaobo-li/hrqglas")
+install_github("bssherwood/rqpen")
 library(rqPen)
 library(hrqglas)
 library(quantreg)
@@ -8,8 +14,26 @@ x <- barro[,-1]
 groups <- c(rep(1,4),rep(2,3),rep(3,3),rep(4,3))
 
 
-r1 <- rq.pen(x,y)
+#r1 <- rq.pen(x,y)
+lamMax <- rqPen:::getLamMaxGroup(x, y, groups, .5, rep(1,4), 
+                         penalty = "gLASSO", TRUE)
+eps <- ifelse(nrow(x) < ncol(x), 0.01, 1e-04)
+nlambda <- 100
+lambda <- exp(seq(log(lamMax), log(eps * lamMax), length.out = nlambda))
+hrq_glasso(x,y,groups,tau=.5,lambda=lambda)
+#figure out the difference in the lambda maximum values. 
+fit <- hrq_glasso(x,y,groups,tau=.5)
 
-
-fit <- hrq_glasso(x,y,groups,tau=.5,lambda=r1$lambda)
+#fit <- hrq_glasso(x,y,groups,tau=.5,lambda=r1$lambda)
+x <- as.matrix(x)
 r2 <- rq.group.pen(x,y,groups=groups)
+
+weights <- rep(1,length(y))
+w.lambda <- rep(1,4)
+
+b.int <- quantile(y, probs = tau)
+grad_k <- -neg.gradient(r0, weights, tau, gamma = gamma, 
+                        x, n, apprx)
+grad_k.norm <- tapply(grad_k, group.index, l2norm)
+lambda.max <- max(grad_k.norm/w.lambda)
+r <- y - b.int

--- a/ignore/test.R
+++ b/ignore/test.R
@@ -1,0 +1,15 @@
+library(rqPen)
+library(hrqglas)
+library(quantreg)
+data(barro)
+y <- barro$y.net
+x <- barro[,-1]
+
+groups <- c(rep(1,4),rep(2,3),rep(3,3),rep(4,3))
+
+
+r1 <- rq.pen(x,y)
+
+
+fit <- hrq_glasso(x,y,groups,tau=.5,lambda=r1$lambda)
+r2 <- rq.group.pen(x,y,groups=groups)

--- a/ignore/test.R
+++ b/ignore/test.R
@@ -2,9 +2,9 @@ rm(list=ls(all=TRUE))
 library(devtools)
 devtools::unload("rqPen")
 devtools::unload("hrqglas")
-install_github("shaobo-li/hrqglas")
-3
 install_github("bssherwood/hrqglas")
+3
+install_github("bssherwood/rqPen")
 3
 library(rqPen)
 library(hrqglas)

--- a/ignore/test.R
+++ b/ignore/test.R
@@ -3,24 +3,71 @@ library(devtools)
 devtools::unload("rqPen")
 devtools::unload("hrqglas")
 install_github("shaobo-li/hrqglas")
+3
 install_github("bssherwood/rqpen")
+3
 library(rqPen)
 library(hrqglas)
 library(quantreg)
 data(barro)
 y <- barro$y.net
-x <- barro[,-1]
+x <- as.matrix(barro[,-1])
 
 groups <- c(rep(1,4),rep(2,3),rep(3,3),rep(4,3))
 
 
 #r1 <- rq.pen(x,y)
 lamMax <- rqPen:::getLamMaxGroup(x, y, groups, .5, rep(1,4), 
-                         penalty = "gLASSO", TRUE)
+                         penalty = "gLASSO", scalex=TRUE)
 eps <- ifelse(nrow(x) < ncol(x), 0.01, 1e-04)
 nlambda <- 100
 lambda <- exp(seq(log(lamMax), log(eps * lamMax), length.out = nlambda))
-hrq_glasso(x,y,groups,tau=.5,lambda=lambda)
+
+h0 <- hrq_glasso(x,y,groups,tau=.5)
+h1 <- hrq_glasso(x,y,groups,tau=.5,lambda=lambda)
+r1 <- rq.group.pen(x,y,groups=groups)
+
+
+getLamMaxGroup <- function(x,y,group.index,tau=.5,group.pen.factor,gamma=.2,gamma.max=4,gamma.q=.1,penalty="gLASSO",scalex=TRUE){
+  # code improvement: Hacky approach to the group.pen.factor issue. 
+  returnVal <- 0
+  n <- length(y)
+  if(scalex){
+    x <- scale(x)
+  }
+  validSpots <- which(group.pen.factor!=0)
+  for(tau_val in tau){
+    r <- y - quantile(y,tau_val)
+    gamma0<- min(gamma.max, max(gamma, quantile(abs(r), probs = gamma.q)))
+    
+    grad_k<- -neg.gradient(r, rep(1,n), tau_val, gamma=gamma0, x, apprx="huber")
+    grad_k.norm<- tapply(grad_k, group.index, l2norm)
+    
+    lambda.max<- max(c(returnVal,grad_k.norm[validSpots]/group.pen.factor[validSpots]))
+  }
+  lambda.max
+}
+
+n <- length(y)
+tau <- .5
+gamma.max <- 4
+gamma0 <- .2
+weights <- rep(1,n)
+group.index <- groups
+
+b.int<- quantile(y, probs = tau)
+r<- y-b.int
+gamma.max<- 4; 
+gamma<- min(gamma.max, max(gamma0, quantile(abs(r), probs = 0.1)))
+
+r0 <- r
+apprx <- "huber"
+grad_k<- -hrqglas:::neg.gradient(r0, weights, tau, gamma=gamma, x, n, apprx)
+grad_k.norm<- tapply(grad_k, group.index, hrqglas:::l2norm)
+
+lambda.max<- max(grad_k.norm/w.lambda)
+
+
 #figure out the difference in the lambda maximum values. 
 fit <- hrq_glasso(x,y,groups,tau=.5)
 


### PR DESCRIPTION
I have updated the code to allow lambda.discard with user specified values. Previously we had it automatically set to false if the values are user specified. Any user can set lambda.discard set to FALSE if they don't want to use that feature. Helpful for me to allow this because rq.pen is generating its own lambda values and then sending them to hrq_glasso(), but I would still like the lambda sequence to terminate if they are getting stuck in an area. 

Also, I'm not sure if I am doing any of this correctly in github so this is an experiment for that!