### PR TITLE
Update hrq_glasso.R

### DIFF
--- a/R/hrq_glasso.R
+++ b/R/hrq_glasso.R
@@ -72,6 +72,10 @@ hrq_glasso<- function(x, y, group.index, tau=0.5, lambda=NULL, weights=NULL, w.l
   if(!(apprx %in% c("huber", "tanh"))){
     stop("must use 'huber' or 'tanh' for apprx")
   }
+  if( sum(apply(x,2,sd)==0) >0 ){
+	stop("one x variable is constant. This can occur when using cross-validation with predictors that have a vast majority of 0s or 1s becuase for one of the training data sets the variable will appear constant.")
+  }
+
   
   if(min(group.index)!=1 | max(group.index)!=length(unique(group.index)) | !is.numeric(group.index)){
     stop("'group.index' must be numeric sequence starting from 1.")


### PR DESCRIPTION
I have updated the code to include a stop message if a constant variable is used as a predictor. This can happen when using cross-validation with a predictor that has very few 0s or 1s. Then in one of the training data sets it will have no 0s or 1s. This was causing some errors in the code, but not in a way that was easy to understand. The update should provide more feedback for the users. 